### PR TITLE
fix: Use headless Bun I/O in `--silent`

### DIFF
--- a/src/BunDotNet.Cli/WrapperCommand.cs
+++ b/src/BunDotNet.Cli/WrapperCommand.cs
@@ -77,6 +77,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
         return await runtime.RunAsync(
             args: context.Remaining.Raw.ToArray(),
             workingDirectory: Environment.CurrentDirectory,
+            headless: settings.Silent,
             cancellationToken: cancellationToken
         );
     }

--- a/src/BunDotNet.Cli/WrapperCommand.cs
+++ b/src/BunDotNet.Cli/WrapperCommand.cs
@@ -42,7 +42,10 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
         CancellationToken cancellationToken
     )
     {
-        if (!settings.Silent)
+        var isNonInteractive = Console.IsInputRedirected || Console.IsOutputRedirected;
+        var effectiveSilent = settings.Silent || isNonInteractive;
+
+        if (!effectiveSilent)
         {
             AnsiConsole.Write(new FigletText("BunDotNet").Color(Color.DarkCyan));
         }
@@ -56,7 +59,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
             return 1;
         }
 
-        var runtime = settings.Silent switch
+        var runtime = effectiveSilent switch
         {
             true => await BunInstaller.InstallAsync(
                 version: _version,
@@ -68,7 +71,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
             ),
         };
 
-        if (!settings.Silent)
+        if (!effectiveSilent)
         {
             AnsiConsole.MarkupLine($"[green]Wrapper: Executing Bun {runtime.Metadata.Version}[/]");
             AnsiConsole.WriteLine();
@@ -77,7 +80,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
         return await runtime.RunAsync(
             args: context.Remaining.Raw.ToArray(),
             workingDirectory: Environment.CurrentDirectory,
-            headless: settings.Silent,
+            headless: effectiveSilent,
             cancellationToken: cancellationToken
         );
     }

--- a/src/BunDotNet.Cli/WrapperCommand.cs
+++ b/src/BunDotNet.Cli/WrapperCommand.cs
@@ -42,10 +42,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
         CancellationToken cancellationToken
     )
     {
-        var isNonInteractive = Console.IsInputRedirected || Console.IsOutputRedirected;
-        var effectiveSilent = settings.Silent || isNonInteractive;
-
-        if (!effectiveSilent)
+        if (!settings.Silent)
         {
             AnsiConsole.Write(new FigletText("BunDotNet").Color(Color.DarkCyan));
         }
@@ -59,7 +56,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
             return 1;
         }
 
-        var runtime = effectiveSilent switch
+        var runtime = settings.Silent switch
         {
             true => await BunInstaller.InstallAsync(
                 version: _version,
@@ -71,7 +68,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
             ),
         };
 
-        if (!effectiveSilent)
+        if (!settings.Silent)
         {
             AnsiConsole.MarkupLine($"[green]Wrapper: Executing Bun {runtime.Metadata.Version}[/]");
             AnsiConsole.WriteLine();
@@ -80,7 +77,7 @@ public class WrapperCommand : AsyncCommand<WrapperCommand.Settings>
         return await runtime.RunAsync(
             args: context.Remaining.Raw.ToArray(),
             workingDirectory: Environment.CurrentDirectory,
-            headless: effectiveSilent,
+            headless: settings.Silent,
             cancellationToken: cancellationToken
         );
     }

--- a/src/BunDotNet/BunRuntime.cs
+++ b/src/BunDotNet/BunRuntime.cs
@@ -13,15 +13,16 @@ public sealed class BunRuntime
     /// <summary>
     /// Set up a process to run Bun with the given arguments and working directory. It must be started manually.
     /// </summary>
-    public Process SetupProcess(string[] args, string workingDirectory)
+    public Process SetupProcess(string[] args, string workingDirectory, bool headless = false)
     {
         var process = new Process
         {
             StartInfo = new ProcessStartInfo
             {
                 FileName = ExecutablePath,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
+                RedirectStandardOutput = headless,
+                RedirectStandardError = headless,
+                RedirectStandardInput = headless,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 WorkingDirectory = workingDirectory,
@@ -41,10 +42,24 @@ public sealed class BunRuntime
     /// </summary>
     /// <exception cref="OperationCanceledException">Thrown if the operation is canceled.</exception>
     /// <returns>The exit code of the Bun process.</returns>
-    public async Task<int> RunAsync(string[] args, string workingDirectory, CancellationToken cancellationToken = default)
+    public async Task<int> RunAsync(
+        string[] args,
+        string workingDirectory,
+        bool headless = false,
+        CancellationToken cancellationToken = default
+    )
     {
-        var process = SetupProcess(args, workingDirectory);
+        var process = SetupProcess(args, workingDirectory, headless);
         process.Start();
+        Task? stdoutDrain = null;
+        Task? stderrDrain = null;
+        if (headless)
+        {
+            process.StandardInput.Close();
+            stdoutDrain = process.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
+            stderrDrain = process.StandardError.BaseStream.CopyToAsync(Stream.Null);
+        }
+
         try
         {
             await process.WaitForExitAsync(cancellationToken);
@@ -57,6 +72,13 @@ public sealed class BunRuntime
                 e,
                 cancellationToken
             );
+        }
+        finally
+        {
+            if (stdoutDrain is not null && stderrDrain is not null)
+            {
+                await Task.WhenAll(stdoutDrain, stderrDrain);
+            }
         }
 
         return process.ExitCode;


### PR DESCRIPTION
This contains a SPECULATIVE fix for random hangs when Bun is run from MSBuild `Exec` by changing the `--silent` path to run Bun in headless mode:

In MudBlazor, the `BuildWebAssets` target has been intermittently hanging indefinitely on this exec: `dotnet tool run bun -- wrapper --version 1.3.9 --path ../../tools --silent -- run build.mjs`, but only through `dotnet build`. it works if you run it in a regular terminal.
